### PR TITLE
Duplicate namespace removed

### DIFF
--- a/example/simple.js
+++ b/example/simple.js
@@ -5,7 +5,7 @@ var db = new Datastore( { inMemoryOnly: true });
 var model = {
     namespace: "jsreport",
     entityTypes: {
-        "jsreport.UserType": {
+        "UserType": {
             "_id": {"type": "Edm.String", key: true},
             "test": {"type": "Edm.String"}//,
             //"num": {"type": "Edm.Int32"},


### PR DESCRIPTION
Prune is truncating namespace + "." from entitySet.entityType and looking for the remaining in model.entityTypes. So this example was failing when the users collection is requested. 

Removing duplicate namespace from entityTypes resolved the issue