### PR TITLE
computation of base pathname

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This is how you can create an OData server with node.js http module and nedb.
 var http = require('http');
 var Datastore = require('nedb');
 var db = new Datastore( { inMemoryOnly: true });
-var ODataServer = require("odata-simple-server");
+var ODataServer = require("simple-odata-server");
 
 var model = {
     namespace: "jsreport",

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This is how you can create an OData server with node.js http module and nedb.
 var http = require('http');
 var Datastore = require('nedb');
 var db = new Datastore( { inMemoryOnly: true });
-var ODataServer = require("simple-odata-server");
+var ODataServer = require("odata-simple-server");
 
 var model = {
     namespace: "jsreport",

--- a/lib/odataServer.js
+++ b/lib/odataServer.js
@@ -42,7 +42,7 @@ ODataServer.prototype.handle = function (req, res) {
     if (!this.cfg.serviceUrl && !req.protocol)
         throw new Error("Unable to determine service url from the express request or value provided in the ODataServer constructor.");
 
-    var path = req.originalUrl.replace(new RegExp(req.url + '$'), "");;
+    var path = (req.originalUrl || "/").replace(new RegExp(req.url + '$'), "");;
     this.cfg.serviceUrl = this.serviceUrl ? this.serviceUrl : (req.protocol + '://' + req.get('host') + path);
 
     var prefix = url.parse(this.cfg.serviceUrl).pathname;

--- a/lib/odataServer.js
+++ b/lib/odataServer.js
@@ -42,6 +42,7 @@ ODataServer.prototype.handle = function (req, res) {
     if (!this.cfg.serviceUrl && !req.protocol)
         throw new Error("Unable to determine service url from the express request or value provided in the ODataServer constructor.");
 
+    // If mounted in express, trim off the subpath (req.url) giving us just the base path
     var path = (req.originalUrl || "/").replace(new RegExp(req.url + '$'), "");;
     this.cfg.serviceUrl = this.serviceUrl ? this.serviceUrl : (req.protocol + '://' + req.get('host') + path);
 

--- a/lib/odataServer.js
+++ b/lib/odataServer.js
@@ -42,7 +42,8 @@ ODataServer.prototype.handle = function (req, res) {
     if (!this.cfg.serviceUrl && !req.protocol)
         throw new Error("Unable to determine service url from the express request or value provided in the ODataServer constructor.");
 
-    this.cfg.serviceUrl = this.serviceUrl ? this.serviceUrl : (req.protocol + '://' + req.get('host') + req.originalUrl.replace(req.url, ""));
+    var path = req.originalUrl.replace(new RegExp(req.url + '$'), "");;
+    this.cfg.serviceUrl = this.serviceUrl ? this.serviceUrl : (req.protocol + '://' + req.get('host') + path);
 
     var prefix = url.parse(this.cfg.serviceUrl).pathname;
     if (!this.router || (prefix !== this.router.prefix)) {


### PR DESCRIPTION
Fixed computation of base pathname to trim subpath off of the end of the originalUrl, not just removing it everywhere in the originalUrl.  Error was visible in the JSON from http GET of the base.  Also handle case where originalUrl was null, as it is in the README.md example.