### PR TITLE
Fix XML headers for metadata retrieval

### DIFF
--- a/lib/odataServer.js
+++ b/lib/odataServer.js
@@ -59,7 +59,12 @@ ODataServer.prototype._initializeRoutes = function () {
     var self = this;
     this.router.get("/\$metadata", function(req, res) {
         var result = metadata(self.cfg);
-        res.writeHead(200, {'Content-Type': 'application/xml', 'DataServiceVersion': '4.0', 'OData-Version': '4.0'});
+        res.writeHead(200, {
+            'Content-Type': 'application/xml', 
+            'DataServiceVersion': '4.0', 
+            'OData-Version': '4.0',
+            "Accept": "application/atom+xml,text/html,application/xhtml+xml,application/xml"
+        });
         return res.end(result);
     });
     this.router.get("/:collection/\$count/", function(req, res) {


### PR DESCRIPTION
pplication/atom+xml must be defined in the Accept header for some odata clients to function properly.

In my case, this is for Tableau: before, i would get the error:
Bad OData Format. Make sure you are using a URL that points to a valid OData Source.

adding application/atom+xml to Accept headers fixes the issue