### PR TITLE
removed unnecessary for()

### DIFF
--- a/lib/prune.js
+++ b/lib/prune.js
@@ -50,7 +50,5 @@ module.exports = function(model, collection, docs) {
     var entitySet = model.entitySets[collection];
     var entityType = model.entityTypes[entitySet.entityType.replace(model.namespace + ".", "")];
 
-    for (var i in docs) {
-        prune(docs, model, entityType);
-    }
+    prune(docs, model, entityType);
 };


### PR DESCRIPTION
This should optimize execution time, because if I'm not wrong this `for` loops unnecessarily the same `docs` variable over and over not matter what, and the array case is already handled in `prune` function (line 3).