### PR TITLE
Update odataServer.js - add /:collection/\$metadata route

### DIFF
--- a/lib/odataServer.js
+++ b/lib/odataServer.js
@@ -66,6 +66,11 @@ ODataServer.prototype._initializeRoutes = function () {
         res.writeHead(200, {'Content-Type': 'application/xml', 'DataServiceVersion': '4.0', 'OData-Version': '4.0'});
         return res.end(result);
     });
+    this.router.get("/:collection/\$metadata", function(req, res) {
+        var result = metadata(self.cfg);
+        res.writeHead(200, {'Content-Type': 'application/xml', 'DataServiceVersion': '4.0', 'OData-Version': '4.0'});
+        return res.end(result);
+    });
     this.router.get("/:collection/\$count/", function(req, res) {
         req.params.$count = true;
         query(self.cfg, req, res);


### PR DESCRIPTION
Added additional /:collection/\$metadata route so the root path is not used by simple-data-server.
I need the server to return a nicely formatted http error (not in odata format) when a client sends an incorrect url. I don't want odata to handle root path. 