### PR TITLE
Avoid invalid HTTP status codes in HTTP response

### DIFF
--- a/lib/odataServer.js
+++ b/lib/odataServer.js
@@ -104,7 +104,7 @@ ODataServer.prototype._initializeRoutes = function () {
   this.router.error(function (req, res, error) {
     function def (e) {
       self.emit('odata-error', e)
-      res.writeHead(error.code || 500, {'Content-Type': 'application/json'})
+      res.writeHead((error.code < 500) ? error.code : 500, {'Content-Type': 'application/json'})
       res.end(JSON.stringify({
         'error': {
           'code': error.code || 500,


### PR DESCRIPTION
I had an error code 11000, which is no valid HTTP status, so the HTTP server package exited the process violently. This should be catched. 