### PR TITLE
Error during creating entity with space in _id

### DIFF
--- a/lib/insert.js
+++ b/lib/insert.js
@@ -34,7 +34,7 @@ function processBody (data, cfg, req, res) {
       res.writeHead(201, cfg.addCorsToHeaders({
         'Content-Type': 'application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8',
         'OData-Version': '4.0',
-        'Location': cfg.serviceUrl + '/' + req.params.collection + "/('" + entity._id + "')"
+        'Location': cfg.serviceUrl + '/' + req.params.collection + "/('" + encodeURI(entity._id) + "')"
       }))
 
       cfg.pruneResults(req.params.collection, entity)


### PR DESCRIPTION
During creating entity with set _id and this _id contains invalid characters like space we are receiving an error from http module.Simple add encodeURI fix this issue