### PR TITLE
If ComplexType is empty to do not include.

### DIFF
--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -65,7 +65,7 @@ function buildMetadata (model) {
     })
   }
 
-  return builder.create({
+  var returnObject = {
     'edmx:Edmx': {
       '@xmlns:edmx': 'http://docs.oasis-open.org/odata/ns/edmx',
       '@Version': '4.0',
@@ -74,11 +74,15 @@ function buildMetadata (model) {
           '@xmlns': 'http://docs.oasis-open.org/odata/ns/edm',
           '@Namespace': model.namespace,
           'EntityType': entityTypes,
-          'ComplexType': complexTypes,
           'EntityContainer': container
-
         }
       }
     }
-  }).end({pretty: true})
+  }
+
+  if (complexTypes.length) {
+    returnObject['edmx:Edmx']['edmx:DataServices'].Schema.ComplexType = complexTypes
+  }
+
+  return builder.create(returnObject).end({pretty: true})
 }


### PR DESCRIPTION
Do not include and empty ComplexType node (<ComplexType /> if there are no complex types.  Including the empty node can cause issues during parsing.
