### PR TITLE
Fix sending headers too early

### DIFF
--- a/lib/insert.js
+++ b/lib/insert.js
@@ -48,11 +48,11 @@ function processBody (data, cfg, req, res) {
         return res.odataError(err)
       }
 
-      res.writeHead(201, cfg.addCorsToHeaders({
-        'Content-Type': 'application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8',
-        'OData-Version': '4.0',
-        'Location': cfg.serviceUrl + '/' + req.params.collection + "/('" + encodeURI(entity._id) + "')"
-      }))
+      res.statusCode = 201;
+      res.setHeader("Content-Type", "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8");
+      res.setHeader("OData-Version", "4.0");
+      res.setHeader("Location", cfg.serviceUrl + '/' + req.params.collection + "/('" + encodeURI(entity._id) + "')");
+      cfg.addCorsToResponse(res);
 
       cfg.pruneResults(req.params.collection, entity)
 

--- a/lib/odataServer.js
+++ b/lib/odataServer.js
@@ -36,7 +36,8 @@ function ODataServer (serviceUrl) {
     base64ToBuffer: ODataServer.prototype.base64ToBuffer.bind(this),
     bufferToBase64: ODataServer.prototype.bufferToBase64.bind(this),
     pruneResults: ODataServer.prototype.pruneResults.bind(this),
-    addCorsToHeaders: ODataServer.prototype.addCorsToHeaders.bind(this)
+    addCorsToHeaders: ODataServer.prototype.addCorsToHeaders.bind(this),
+    addCorsToResponse: ODataServer.prototype.addCorsToResponse.bind(this)
   }
 }
 
@@ -68,7 +69,10 @@ ODataServer.prototype._initializeRoutes = function () {
   var self = this
   this.router.get('/\$metadata', function (req, res) {
     var result = metadata(self.cfg)
-    res.writeHead(200, self.cfg.addCorsToHeaders({'Content-Type': 'application/xml', 'DataServiceVersion': '4.0', 'OData-Version': '4.0'}))
+    res.statusCode = 200;
+    res.setHeader("Content-Type", "application/xml");
+    res.setHeader("DataServiceVersion", "4.0");
+    res.setHeader("OData-Version", "4.0");
     return res.end(result)
   })
   this.router.get('/:collection/\$count', function (req, res) {
@@ -83,7 +87,8 @@ ODataServer.prototype._initializeRoutes = function () {
   })
   this.router.get('/', function (req, res) {
     var result = collections(self.cfg)
-    res.writeHead(200, self.cfg.addCorsToHeaders({'Content-Type': 'application/json'}))
+    res.statusCode = 200;
+    res.setHeader("Content-Type", "application/json");
     return res.end(result)
   })
   this.router.post('/:collection', function (req, res) {
@@ -98,7 +103,8 @@ ODataServer.prototype._initializeRoutes = function () {
 
   if (this.cfg.cors) {
     this.router.options('/(.*)', function (req, res) {
-      res.writeHead(200, {'Access-Control-Allow-Origin': self.cfg.cors})
+      res.statusCode = 200;
+      res.setHeader("Access-Control-Allow-Origin", self.cfg.cors);
       res.end()
     })
   }
@@ -106,7 +112,8 @@ ODataServer.prototype._initializeRoutes = function () {
   this.router.error(function (req, res, error) {
     function def (e) {
       self.emit('odata-error', e)
-      res.writeHead((error.code && error.code >= 100 && error.code < 600) ? error.code : 500, self.cfg.addCorsToHeaders({'Content-Type': 'application/json'}))
+      res.statusCode = (error.code && error.code >= 100 && error.code < 600) ? error.code : 500;
+      res.setHeader("Content-Type", "application/json");
       res.end(JSON.stringify({
         'error': {
           'code': error.code || 500,
@@ -346,6 +353,12 @@ ODataServer.prototype.addCorsToHeaders = function (headers) {
   }
 
   return headers
+}
+
+ODataServer.prototype.addCorsToResponse = function (res) {
+  if (this.cfg.cors) {
+    res.setHeader('Access-Control-Allow-Origin', this.cfg.cors);
+  }
 }
 
 module.exports = ODataServer

--- a/lib/query.js
+++ b/lib/query.js
@@ -65,10 +65,11 @@ module.exports = function (cfg, req, res) {
       return res.odataError(err)
     }
 
-    res.writeHead(200, cfg.addCorsToHeaders({
-      'Content-Type': 'application/json;odata.metadata=minimal',
-      'OData-Version': '4.0'
-    }))
+    res.statusCode = 200;
+    res.setHeader("Content-Type", "application/json;odata.metadata=minimal");
+    res.setHeader("OData-Version", "4.0");
+    cfg.addCorsToResponse(res);
+    
     var out = {}
     // define the @odataContext in case of selection
     var sAdditionIntoContext = ''

--- a/lib/remove.js
+++ b/lib/remove.js
@@ -17,7 +17,8 @@ module.exports = function (cfg, req, res) {
         return res.odataError(e)
       }
 
-      res.writeHead(204, cfg.addCorsToHeaders())
+      res.statusCode = 204;
+      cfg.addCorsToResponse(res);
       res.end()
     })
   } catch (e) {

--- a/lib/update.js
+++ b/lib/update.js
@@ -42,7 +42,8 @@ function processBody (body, cfg, req, res) {
         return res.odataError(e)
       }
 
-      res.writeHead(204, cfg.addCorsToHeaders())
+      res.statusCode = 204;
+      cfg.addCorsToResponse(res);
       res.end()
     })
   } catch (e) {


### PR DESCRIPTION
During errors, the node process would terminate due to sending successful headers too early, before the error occurred. This can be fixed by not using `.writeHead` and instead using `.setHeader`.