### PR TITLE
Fix getEntity from EntitySet

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -81,13 +81,12 @@ module.exports = function (cfg, req, res) {
         ctr++
       }
     }
-    if (queryOptions['$filter'].hasOwnProperty('_id')) {
+    if (queryOptions['$filter'].hasOwnProperty('_id') && (req.path !== ("/" + queryOptions.collection))) {
       sAdditionIntoContext = sAdditionIntoContext.length > 0 ? '(' + sAdditionIntoContext + ')/$entity' : '/$entity'
       out['@odata.context'] = cfg.serviceUrl + '/$metadata#' + req.params.collection + sAdditionIntoContext
       for (var key in result) {
         out[key] = result[key]
       }
-      out['value'] = result
     } else {
       sAdditionIntoContext = sAdditionIntoContext.length > 0 ? '(' + sAdditionIntoContext + ')' : ''
       out = {


### PR DESCRIPTION
Fixing some odd behaviour when filtering by ID and when using getEntity (a.k.a. `/entity('abc')`).